### PR TITLE
support all kinds of iterators without failing silently

### DIFF
--- a/tests/test_rmap.py
+++ b/tests/test_rmap.py
@@ -28,3 +28,10 @@ def test_dict():
 def test_complex_nested():
     obj = ['1', 2, ({3: 4}, {5, '6'})]
     assert rmap(obj, square, int) == ['1', 4, ({3: 16}, {'6', 25})]
+
+
+def test_unusual_mapping():
+    from collections import Counter
+    c = Counter([1,2,2])
+    assert rmap(c, square, int) == Counter([1,2,2,2,2])
+


### PR DESCRIPTION
Instead of hard coding types we want to support, as in
```
if hasattr(obj, '__iter__'):
    gen = (rmap(item, func, typename) for item in obj)
return (list(gen)  if isinstance(obj, list) else
        tuple(gen) if isinstance(obj, tuple) else
        set(gen)   if isinstance(obj, set) else
        {k: rmap(v, func, typename)
         for k, v in obj.items()} if isinstance(obj, dict) else
        obj)
```
we can cleanly support all iterables/collections, plus all mappings even if they're not dicts, all using type constructors determined dynamically.
```
if isinstance(obj, Mapping):                                         
    return type(obj)({k: rmap(obj[k], func, typename) for k in obj}) 
if isinstance(obj, Iterable):                                        
    return type(obj)(rmap(item, func, typename) for item in obj)     
```
Additionally, this prevents us from failing silently when we `else return obj` without performing applying `func` at all.


The only weird thing we have to do which is deal with the fact that Python's iterable ecosystem has a big exception: strings! In a perfect world we might get
```
>>> str(('a','b','c'))
>>> 'abc'
```
but of course we get a visual represenation of the object we passed in instead of a new object created from the iterable.
```
>>> str(('a','b','c'))
>>> "('a', 'b', 'c')"
```
Of course this is convenient when programming IRL, but it does kinda ruin this case. So we have to add a case for this special python behavior.