### PR TITLE
Standard lib map API

### DIFF
--- a/skrt/utils.py
+++ b/skrt/utils.py
@@ -78,7 +78,7 @@ def match(fields, objs):
     return all(dict_ == subdicts[0] for dict_ in subdicts)
 
 
-def rmap(obj, func, typename):
+def rmap(func, obj, typename):
     """
     Recursivley maps a function onto an object or elements of a container.
 
@@ -94,11 +94,11 @@ def rmap(obj, func, typename):
     Examples
     --------
     >>> obj = [1, 2, 3, 4, '1']
-    >>> rmap(obj, lambda x: x**2, int)
+    >>> rmap(lambda x: x**2, obj, int)
     [1, 4, 9, 16, '1']
 
     >>> obj = [1, 2, 3, 4, 'Word', {'WORD': 'WORD'}]
-    >>> rmap(obj, lambda x: x.lower(), str)
+    >>> rmap(lambda x: x.lower(), obj, str)
     [1, 2, 3, 4, 'word', {'WORD': 'word'}]
 
     """
@@ -114,6 +114,6 @@ def rmap(obj, func, typename):
         return obj
 
     if isinstance(obj, Mapping):
-        return type(obj)({k: rmap(obj[k], func, typename) for k in obj})
+        return type(obj)({k: rmap(func, obj[k], typename) for k in obj})
     if isinstance(obj, Iterable):
-        return type(obj)(rmap(item, func, typename) for item in obj)
+        return type(obj)(rmap(func, item, typename) for item in obj)

--- a/tests/test_rmap.py
+++ b/tests/test_rmap.py
@@ -7,31 +7,30 @@ def square(x):
 
 def test_list():
     list_ = [1, 2, 3, 4, 5]
-    assert rmap(list_, square, int) == [1, 4, 9, 16, 25]
+    assert rmap(square, list_, int) == [1, 4, 9, 16, 25]
 
 
 def test_tuple():
     tuple_ = (1, 2, 3, 4, 5)
-    assert rmap(tuple_, square, int) == (1, 4, 9, 16, 25)
+    assert rmap(square, tuple_, int) == (1, 4, 9, 16, 25)
 
 
 def test_set():
     set_ = {1, 2, 3, 4, 5}
-    assert rmap(set_, square, int) == {1, 4, 9, 16, 25}
+    assert rmap(square, set_, int) == {1, 4, 9, 16, 25}
 
 
 def test_dict():
     dict_ = {'a': 1, 'b': 2, 'c': 3}
-    assert rmap(dict_, square, int) == {'a': 1, 'b': 4, 'c': 9}
+    assert rmap(square, dict_, int) == {'a': 1, 'b': 4, 'c': 9}
 
 
 def test_complex_nested():
     obj = ['1', 2, ({3: 4}, {5, '6'})]
-    assert rmap(obj, square, int) == ['1', 4, ({3: 16}, {'6', 25})]
+    assert rmap(square, obj, int) == ['1', 4, ({3: 16}, {'6', 25})]
 
 
 def test_unusual_mapping():
     from collections import Counter
     c = Counter([1,2,2])
-    assert rmap(c, square, int) == Counter([1,2,2,2,2])
-
+    assert rmap(square, c, int) == Counter([1,2,2,2,2])

--- a/tests/test_rmap.py
+++ b/tests/test_rmap.py
@@ -28,3 +28,10 @@ def test_dict():
 def test_complex_nested():
     obj = ['1', 2, ({3: 4}, {5, '6'})]
     assert rmap(obj, square, int) == ['1', 4, ({3: 16}, {'6', 25})]
+
+
+def test_unusual_mapping():
+    from collections import Counter
+    c = Counter([1,2,2])
+    assert rmap(c, square, int) == Counter([1,2,2,2,2])
+


### PR DESCRIPTION
We can swap the arguments `func` and `obj` to match the API provided by Python's [native map](https://docs.python.org/3/library/functions.html#map):

> map(function, iterable, ...)
Return an iterator that applies function to every item of iterable, yielding the results. If additional iterable arguments are passed, function must take that many arguments and is applied to the items from all iterables in parallel...

We can keep `typename` on the end to support future optional argument.